### PR TITLE
Configure dynamic clients

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,7 @@ const schemas = require('screwdriver-data-schema');
 const vogels = require('vogels');
 
 const DEFAULT_REGION = 'us-west-2';
-const TABLE_SCHEMAS = {
-    builds: schemas.models.build.base,
-    jobs: schemas.models.job.base,
-    pipelines: schemas.models.pipeline.base,
-    platforms: schemas.models.platform.base,
-    users: schemas.models.user.base
-};
+const TABLE_MODELS = schemas.models;
 
 class Dynamodb extends Datastore {
     /**
@@ -37,11 +31,13 @@ class Dynamodb extends Datastore {
         vogels.AWS.config.update(awsConfig);
 
         this.client = {};
-        Object.keys(TABLE_SCHEMAS).forEach((table) => {
-            this.client[table] = vogels.define(table, {
+        Object.keys(TABLE_MODELS).forEach((modelName) => {
+            const model = TABLE_MODELS[modelName];
+
+            this.client[model.tableName] = vogels.define(modelName, {
                 hashKey: 'id',
-                schema: TABLE_SCHEMAS[table],
-                tableName: table
+                schema: model.base,
+                tableName: model.tableName
             });
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,11 +40,22 @@ describe('index test', () => {
 
         dataSchemaMock = {
             models: {
-                build: { base: sinon.stub() },
-                job: { base: sinon.stub() },
-                pipeline: { base: sinon.stub() },
-                platform: { base: sinon.stub() },
-                user: { base: sinon.stub() }
+                build: {
+                    base: sinon.stub(),
+                    tableName: 'builds'
+                },
+                job: {
+                    base: sinon.stub(),
+                    tableName: 'jobs'
+                },
+                pipeline: {
+                    base: sinon.stub(),
+                    tableName: 'pipelines'
+                },
+                user: {
+                    base: sinon.stub(),
+                    tableName: 'users'
+                }
             },
             plugins: {
                 datastore: {
@@ -104,7 +115,7 @@ describe('index test', () => {
         });
 
         it('constructs the builds client', () => {
-            assert.calledWith(vogelsMock.define, 'builds', {
+            assert.calledWith(vogelsMock.define, 'build', {
                 hashKey: 'id',
                 schema: dataSchemaMock.models.build.base,
                 tableName: 'builds'
@@ -112,7 +123,7 @@ describe('index test', () => {
         });
 
         it('constructs the jobs client', () => {
-            assert.calledWith(vogelsMock.define, 'jobs', {
+            assert.calledWith(vogelsMock.define, 'job', {
                 hashKey: 'id',
                 schema: dataSchemaMock.models.job.base,
                 tableName: 'jobs'
@@ -120,23 +131,15 @@ describe('index test', () => {
         });
 
         it('constructs the pipelines client', () => {
-            assert.calledWith(vogelsMock.define, 'pipelines', {
+            assert.calledWith(vogelsMock.define, 'pipeline', {
                 hashKey: 'id',
                 schema: dataSchemaMock.models.pipeline.base,
                 tableName: 'pipelines'
             });
         });
 
-        it('constructs the platforms client', () => {
-            assert.calledWith(vogelsMock.define, 'platforms', {
-                hashKey: 'id',
-                schema: dataSchemaMock.models.platform.base,
-                tableName: 'platforms'
-            });
-        });
-
         it('constructs the users client', () => {
-            assert.calledWith(vogelsMock.define, 'users', {
+            assert.calledWith(vogelsMock.define, 'user', {
                 hashKey: 'id',
                 schema: dataSchemaMock.models.user.base,
                 tableName: 'users'


### PR DESCRIPTION
This PR change has it so that instead of hardcoding a list of objects to iterate over and create clients for with Dynamo, we iterate over the models defined in the data-schema

Takes advantage of the `tableName` fields that is now set as well
