### PR TITLE
Capture the error thrown by vogels update

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "promise-nodeify": "0.1.0",
     "screwdriver-data-schema": "^5.0.4",
     "screwdriver-datastore-base": "^1.0.0",
-    "screwdriver-dynamic-dynamodb": "^2.0.0"
+    "screwdriver-dynamic-dynamodb": "^2.0.4"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -372,6 +372,22 @@ describe('index test', () => {
                 done();
             });
         });
+
+        it('fails when it encounters a synchronous error', (done) => {
+            const testError = new Error('testError');
+
+            clientMock.update.throws(testError);
+            datastore._update({
+                table: 'pipelines',
+                params: {
+                    id: 'doNotCare',
+                    data: {}
+                }
+            }, (err) => {
+                assert.deepEqual(err, testError);
+                done();
+            });
+        });
     });
 
     describe('scan', () => {


### PR DESCRIPTION
Proposal to resolve screwdriver-cd/screwdriver#94

There's already a bug opened in the vogels module regarding a thrown error in a callback-style workflow. We've already made a PR to address their issue, but we still want to be guarded against this issue while that PR is reviewed.

The most straightforward way was to wrap the call in a Promise, where it would be handled very well. It uses a separate module `promise-nodeify` to handle the promise-to-callback interface.
