### PR TITLE
Sort functions are only available for query()

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,12 +181,12 @@ class Dynamodb extends Datastore {
                     return false;
                 }
                 scanner = client.query(filterParams[param]).usingIndex(`${param}Index`);
+                scanner = (config.sort === 'ascending') ?
+                    scanner.ascending() : scanner.descending();
 
                 return true;
             });
         }
-
-        scanner = (config.sort === 'ascending') ? scanner.ascending() : scanner.descending();
 
         return scanner.limit(limitTotalCount).exec((err, data) => {
             if (err) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -472,7 +472,7 @@ describe('index test', () => {
             });
         });
 
-        it('scans using index with filter params', (done) => {
+        it('query using index with filter params', (done) => {
             const testFilterParams = {
                 table: 'pipelines',
                 params: {
@@ -505,7 +505,7 @@ describe('index test', () => {
             });
         });
 
-        it('scans using sort option', (done) => {
+        it('query using sort option', (done) => {
             const testFilterParams = {
                 table: 'pipelines',
                 params: {
@@ -525,6 +525,27 @@ describe('index test', () => {
                 assert.isNull(err);
                 assert.isOk(data);
                 assert.calledOnce(scanChainMock.ascending);
+                done();
+            });
+        });
+
+        it('scan with no sorting', (done) => {
+            const testFilterParams = {
+                table: 'pipelines',
+                params: {},
+                paginate: {
+                    count: 2,
+                    page: 2
+                },
+                sort: 'ascending'
+            };
+
+            scanChainMock.limit.returns(scanChainMock);
+            scanChainMock.exec.yieldsAsync(null, responseMock);
+            datastore._scan(testFilterParams, (err, data) => {
+                assert.isNull(err);
+                assert.isOk(data);
+                assert.notCalled(scanChainMock.descending);
                 done();
             });
         });


### PR DESCRIPTION
`ascending()` or `descending()` is not available for `client.scan()`, so it will break all the list endpoints.

I tried to find if there is something like `client.query(*)` to query everything (basically does a scan) but I couldn't find it. 

This needs to be merged before https://github.com/screwdriver-cd/screwdriver/pull/186
