### PR TITLE
[3] Add support for multiple filter params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-dynamodb",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Screwdriver interface with dynamodb",
   "main": "index.js",
   "scripts": {
@@ -38,6 +38,7 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
+    "clone": "^1.0.2",
     "promise-nodeify": "0.1.0",
     "screwdriver-data-schema": "^11.0.0",
     "screwdriver-datastore-base": "^1.0.0",


### PR DESCRIPTION
`query()` can only be called on index
`filter()` can be called on other attributes

This finds the first index and call `query` using that index. Everything else in `params` will be searched using `filter`

Solves https://github.com/screwdriver-cd/screwdriver/issues/188
