### PR TITLE
Only sort if rangeKeys is there

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,8 +219,10 @@ class Dynamodb extends Datastore {
                     scanner.filter(`${param}`).equals(filterParams[param]);
                 });
 
-                scanner = (config.sort === 'ascending')
-                    ? scanner.ascending() : scanner.descending();
+                if (model.rangeKeys) {
+                    scanner = (config.sort === 'ascending')
+                        ? scanner.ascending() : scanner.descending();
+                }
             }
 
             return scanner.limit(limitTotalCount).exec((err, data) => {


### PR DESCRIPTION
@FenrirUnbound  ran into a bug where pipelines/{id}/jobs did not show the correct jobs. (Not sure how we didn't encounter this before!?!)

Traced this back locally and found out that it broke at `sort`. This is because sort() needs rangeKeys to exist. Jobs has pipelineIdIndex, but it doesn't have rangeKey. This PR added a guard for it. 

Refactored the test while I was at it. 
