### PR TITLE
Temporarily remove pagination to fix the limit() bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,6 @@ Scan for records in the datastore. Returns `[]` if the table is empty. Returns e
 |config | Object | Each of its properties defines your get operation |
 |config.table | String | The datastore table name |
 |config.params| Object | Query to filter on |
-|config.paginate| Object | Each of its properties further defines the characteristics for pagination |
-|config.paginate.count| Integer | Number of items per page |
-|config.paginate.page| Integer | Page number of the set you wish for the datastore to return |
 
 **Example**
 
@@ -174,40 +171,10 @@ const datastore = new DynamoDB();
 // successful scan operation
 return datastore.scan({
     table: 'animalNoises',
-    params: {},
-    paginate: {
-        page: 2,
-        count: 2
-    }
+    params: {}
 }).then((data) => {
-    console.log(data); // [{ id: 2, sound: 'meow' }, { id: 3, sound: 'woof' }]
+    console.log(data);
 });
-
-// if animalNoises table only has 10 entries
-return datastore.scan({
-    table: 'animalNoises',
-    params: {},
-    paginate: {
-        page: 3,
-        count: 5
-    }
-}).then((data) => {
-    console.log(data); // []
-});
-
-// scan operation on a non-existing entry
-return datastore.scan({
-    table: 'unicorns',
-    params: {},
-    paginate: {
-        page: 2,
-        count: 2
-    }
-}).then((data) => {
-        // do stuff
-    }, (err) {
-        console.error(err); // [Error: Invalid table name "unicorns"
-    });
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ class Dynamodb extends Datastore {
 
     /**
      * Scan records in the datastore
+     * Pagination is not being used because of DynamoDB's way of combining limit and filter
      * @method scan
      * @param  {Object}   config                Configuration object
      * @param  {String}   config.table          Table name
@@ -190,8 +191,6 @@ class Dynamodb extends Datastore {
     _scan(config) {
         const client = this.clients[config.table];
         const model = this.tableModels[config.table];
-        const limitTotalCount = config.paginate.page * config.paginate.count;
-        const startIndex = (config.paginate.page - 1) * config.paginate.count;
         const filterParams = clone(config.params);
 
         return new Promise((resolve, reject) => {
@@ -223,12 +222,12 @@ class Dynamodb extends Datastore {
                     ? scanner.ascending() : scanner.descending();
             }
 
-            return scanner.limit(limitTotalCount).exec((err, data) => {
+            return scanner.exec((err, data) => {
                 if (err) {
                     return reject(err);
                 }
-                const result = data.Items.slice(startIndex);    // pick out items from page specified
-                const response = result.map((item) => item.toJSON());
+
+                const response = data.Items.map((item) => item.toJSON());
 
                 return resolve(response);
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,7 +36,6 @@ describe('index test', () => {
         scanChainMock = {
             ascending: sinon.stub(),
             descending: sinon.stub(),
-            limit: sinon.stub(),
             exec: sinon.stub(),
             filter: sinon.stub().returns(filterMock)
         };
@@ -165,7 +164,7 @@ describe('index test', () => {
             responseMock.toJSON.returns(testData);
 
             return datastore._get(testParams).then((data) => {
-                assert.deepEqual(testData, data);
+                assert.deepEqual(data, testData);
                 assert.calledWith(clientMock.get, testParams.params.id);
             });
         });
@@ -235,7 +234,7 @@ describe('index test', () => {
                     data: { key: 'value' }
                 }
             }).then((data) => {
-                assert.deepEqual(expectedResult, data);
+                assert.deepEqual(data, expectedResult);
                 assert.calledWith(clientMock.create, {
                     id: 'someIdToPutHere',
                     key: 'value'
@@ -459,15 +458,19 @@ describe('index test', () => {
                 page: 2
             }
         };
-        let count;
+        let count = 4;
         const dynamoItem = { toJSON: sinon.stub() };
-
-        beforeEach(() => {
-            count = testParams.paginate.count * testParams.paginate.page;
-        });
 
         it('scans all the data', () => {
             const testData = [
+                {
+                    id: 'data',
+                    key: 'value'
+                },
+                {
+                    id: 'data',
+                    key: 'value'
+                },
                 {
                     id: 'data',
                     key: 'value'
@@ -479,7 +482,6 @@ describe('index test', () => {
             ];
 
             scanChainMock.descending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
             for (; count > 0; count--) {
@@ -492,7 +494,7 @@ describe('index test', () => {
             });
 
             return datastore._scan(testParams).then((data) => {
-                assert.deepEqual(testData, data);
+                assert.deepEqual(data, testData);
                 assert.calledWith(clientMock.scan);
             });
         });
@@ -514,7 +516,6 @@ describe('index test', () => {
             }
 
             scanChainMock.descending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
             dynamoItem.toJSON.returns({
                 id: 'data',
@@ -546,7 +547,6 @@ describe('index test', () => {
             }
 
             scanChainMock.descending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
             dynamoItem.toJSON.returns({
                 id: 'data',
@@ -576,7 +576,6 @@ describe('index test', () => {
             };
 
             scanChainMock.ascending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
             scanChainMock.filter.returns(filterMock);
 
@@ -605,7 +604,6 @@ describe('index test', () => {
             };
 
             scanChainMock.ascending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
             return datastore._scan(testFilterParams).then(() => {
@@ -625,7 +623,6 @@ describe('index test', () => {
             };
 
             clientMock.scan.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
             return datastore._scan(testFilterParams).then((data) => {
@@ -636,24 +633,15 @@ describe('index test', () => {
 
         it('returns empty array when no keys found', () => {
             scanChainMock.descending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
-            responseMock.Items[0] = dynamoItem;
-
-            dynamoItem.toJSON.returns({
-                id: 'data',
-                key: 'value'
-            });
-
             return datastore._scan(testParams).then((data) => {
-                assert.deepEqual([], data);
+                assert.deepEqual(data, []);
                 assert.calledWith(clientMock.scan);
             });
         });
 
         it('fails when given an unknown table name', () => {
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(new Error('cannot find entries in table'));
 
             return datastore._scan({
@@ -675,7 +663,6 @@ describe('index test', () => {
             const testError = new Error('errorCommunicatingToApi');
 
             scanChainMock.descending.returns(scanChainMock);
-            scanChainMock.limit.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(testError);
 
             return datastore._scan({


### PR DESCRIPTION
DynamoDB does `limit()` first, then `filter()` as opposed to other RDBMS. We are removing pagination for now. Will probably implement pagination a different way using `?from`. I believe nothing should break because of this. Might just make things a little slower than before. 

Related to https://github.com/screwdriver-cd/screwdriver/issues/225
