### PR TITLE
Replace vogels with dynogels (and replace need for dynamic-dynamodb)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-dynamodb",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Screwdriver interface with dynamodb",
   "main": "index.js",
   "scripts": {
@@ -41,6 +41,6 @@
     "clone": "^1.0.2",
     "screwdriver-data-schema": "^13.0.0",
     "screwdriver-datastore-base": "^2.0.0",
-    "screwdriver-dynamic-dynamodb": "^3.0.0"
+    "dynogels": "^6.0.1"
   }
 }


### PR DESCRIPTION
It would be nice if we could call createTable as well (but alas, we can't as we need a callback place).

Resolves https://github.com/screwdriver-cd/dynamic-dynamodb/issues/10
