### PR TITLE
feat(1958): Upgrade hapi dependencies. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ class Dynamodb extends Datastore {
         this.clients = {};
         this.tableModels = {};
 
-        MODEL_NAMES.forEach((modelName) => {
+        MODEL_NAMES.forEach(modelName => {
             const table = defineTable(modelName, this.prefix);
             const model = schemas.models[modelName];
 
@@ -88,7 +88,7 @@ class Dynamodb extends Datastore {
      */
     setup() {
         return new Promise((resolve, reject) => {
-            dynogels.createTables((err) => {
+            dynogels.createTables(err => {
                 if (err) {
                     return reject(err);
                 }
@@ -120,7 +120,7 @@ class Dynamodb extends Datastore {
                 if (err) {
                     return reject(err);
                 }
-                const result = (data) ? data.toJSON() : null;
+                const result = data ? data.toJSON() : null;
 
                 return resolve(result);
             });
@@ -178,7 +178,7 @@ class Dynamodb extends Datastore {
                 return reject(err);
             }
 
-            return client.destroy(config.params.id, (err) => {
+            return client.destroy(config.params.id, err => {
                 if (err) {
                     return reject(err);
                 }
@@ -256,7 +256,7 @@ class Dynamodb extends Datastore {
             let scanner = client.scan();
 
             if (filterParams && Object.keys(filterParams).length > 0) {
-                model.indexes.some((param) => {
+                model.indexes.some(param => {
                     if (filterParams[param]) {
                         scanner = client.query(filterParams[param]).usingIndex(`${param}Index`);
                         delete filterParams[param];
@@ -267,7 +267,7 @@ class Dynamodb extends Datastore {
                     return false;
                 });
 
-                Object.keys(filterParams).forEach((param) => {
+                Object.keys(filterParams).forEach(param => {
                     const value = filterParams[param];
 
                     if (Array.isArray(value)) {
@@ -277,8 +277,7 @@ class Dynamodb extends Datastore {
                     }
                 });
 
-                scanner = (config.sort === 'ascending')
-                    ? scanner.ascending() : scanner.descending();
+                scanner = config.sort === 'ascending' ? scanner.ascending() : scanner.descending();
             }
 
             return scanner.exec((err, data) => {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-datastore-dynamodb",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Screwdriver interface with dynamodb",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -36,18 +36,18 @@
     }
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
+    "chai": "^4.2.0",
+    "eslint": "^7.7.0",
+    "eslint-config-screwdriver": "^5.0.4",
     "eslint-plugin-import": "^2.0.0",
-    "jenkins-mocha": "^3.0.0",
+    "mocha": "^8.1.2",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.4"
+    "sinon": "^9.0.3"
   },
   "dependencies": {
     "clone": "^2.0.0",
-    "dynogels": "^6.0.1",
-    "screwdriver-data-schema": "^15.0.3",
-    "screwdriver-datastore-base": "^2.2.0"
+    "dynogels": "^9.1.0",
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-datastore-base": "^5.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -170,7 +170,7 @@ describe('index test', () => {
             clientMock.get.yieldsAsync(null, responseMock);
             responseMock.toJSON.returns(testData);
 
-            return datastore._get(testParams).then((data) => {
+            return datastore._get(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(clientMock.get, testParams.params.id);
             });
@@ -179,44 +179,51 @@ describe('index test', () => {
         it('gracefully understands that no one is returned when it does not exist', () => {
             clientMock.get.yieldsAsync();
 
-            return datastore._get({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(data => assert.isNull(data));
+            return datastore
+                ._get({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(data => assert.isNull(data));
         });
 
         it('fails when given an unknown table name', () =>
-            datastore._get({
-                table: 'tableUnicorn',
-                params: {
-                    id: 'doesNotMatter'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                ._get({
+                    table: 'tableUnicorn',
+                    params: {
+                        id: 'doesNotMatter'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('errorCommunicatingToApi');
 
             clientMock.get.yieldsAsync(testError);
 
-            return datastore._get({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                ._get({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, testError.message);
+                });
         });
     });
 
@@ -234,19 +241,21 @@ describe('index test', () => {
             clientResponse.toJSON.returns(expectedResult);
             clientMock.create.yieldsAsync(null, clientResponse);
 
-            return datastore._save({
-                table: 'pipelines',
-                params: {
-                    id: 'someIdToPutHere',
-                    data: { key: 'value' }
-                }
-            }).then((data) => {
-                assert.deepEqual(data, expectedResult);
-                assert.calledWith(clientMock.create, {
-                    id: 'someIdToPutHere',
-                    key: 'value'
+            return datastore
+                ._save({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someIdToPutHere',
+                        data: { key: 'value' }
+                    }
+                })
+                .then(data => {
+                    assert.deepEqual(data, expectedResult);
+                    assert.calledWith(clientMock.create, {
+                        id: 'someIdToPutHere',
+                        key: 'value'
+                    });
                 });
-            });
         });
 
         it('fails when it encounters an error', () => {
@@ -254,34 +263,41 @@ describe('index test', () => {
 
             clientMock.create.yieldsAsync(testError);
 
-            return datastore._save({
-                table: 'pipelines',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }, (err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                ._save({
+                    table: 'pipelines',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(
+                    () => {
+                        throw new Error('Oops');
+                    },
+                    err => {
+                        assert.isOk(err, 'Error should be returned');
+                        assert.equal(err.message, testError.message);
+                    }
+                );
         });
 
         it('fails when given an unknown table name', () =>
-            datastore._save({
-                table: 'doesNotExist',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                ._save({
+                    table: 'doesNotExist',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
     });
 
     describe('remove', () => {
@@ -295,42 +311,47 @@ describe('index test', () => {
 
             clientMock.destroy.yieldsAsync(null);
 
-            return datastore._remove(testParams).then((data) => {
+            return datastore._remove(testParams).then(data => {
                 assert.isNull(data);
                 assert.calledWith(clientMock.destroy, testParams.params.id);
             });
         });
 
         it('fails when given an unknown table name', () =>
-            datastore._remove({
-                table: 'tableUnicorn',
-                params: {
-                    id: 'doesNotMatter'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                ._remove({
+                    table: 'tableUnicorn',
+                    params: {
+                        id: 'doesNotMatter'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('errorCommunicatingToApi');
 
             clientMock.destroy.yieldsAsync(testError);
 
-            return datastore._remove({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, testError.message);
-            });
+            return datastore
+                ._remove({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, testError.message);
+                });
         });
     });
 
@@ -349,19 +370,21 @@ describe('index test', () => {
             clientMock.update.yieldsAsync(null, clientReponse);
             clientReponse.toJSON.returns(expectedResult);
 
-            return datastore._update({
-                table: 'pipelines',
-                params: {
-                    id,
-                    data: { targetKey: 'updatedValue' }
-                }
-            }).then((data) => {
-                assert.deepEqual(data, expectedResult);
-                assert.calledWith(clientMock.update, {
-                    id,
-                    targetKey: 'updatedValue'
+            return datastore
+                ._update({
+                    table: 'pipelines',
+                    params: {
+                        id,
+                        data: { targetKey: 'updatedValue' }
+                    }
+                })
+                .then(data => {
+                    assert.deepEqual(data, expectedResult);
+                    assert.calledWith(clientMock.update, {
+                        id,
+                        targetKey: 'updatedValue'
+                    });
                 });
-            });
         });
 
         /*
@@ -382,59 +405,70 @@ describe('index test', () => {
             testError.statusCode = 400;
             clientMock.update.yieldsAsync(testError);
 
-            return datastore._update({
-                table: 'pipelines',
-                params: {
-                    id,
-                    data: {
-                        otherKey: 'value'
+            return datastore
+                ._update({
+                    table: 'pipelines',
+                    params: {
+                        id,
+                        data: {
+                            otherKey: 'value'
+                        }
                     }
-                }
-            }).then((data) => {
-                assert.isNull(data);
-                assert.calledWith(clientMock.update, {
-                    id,
-                    otherKey: 'value'
-                }, {
-                    expected: {
-                        id
-                    }
+                })
+                .then(data => {
+                    assert.isNull(data);
+                    assert.calledWith(
+                        clientMock.update,
+                        {
+                            id,
+                            otherKey: 'value'
+                        },
+                        {
+                            expected: {
+                                id
+                            }
+                        }
+                    );
                 });
-            });
         });
 
         it('fails when given an unknown table name', () =>
-            datastore._update({
-                table: 'doesNotExist',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                ._update({
+                    table: 'doesNotExist',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('testError');
 
             clientMock.update.yieldsAsync(testError);
 
-            return datastore._update({
-                table: 'pipelines',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                ._update({
+                    table: 'pipelines',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, testError.message);
+                });
         });
 
         it('fails when it encounters a synchronous error', () => {
@@ -442,18 +476,21 @@ describe('index test', () => {
 
             clientMock.update.throws(testError);
 
-            return datastore._update({
-                table: 'pipelines',
-                params: {
-                    id: 'doNotCare',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                ._update({
+                    table: 'pipelines',
+                    params: {
+                        id: 'doNotCare',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, testError.message);
+                });
         });
     });
 
@@ -500,7 +537,7 @@ describe('index test', () => {
                 key: 'value'
             });
 
-            return datastore._scan(testParams).then((data) => {
+            return datastore._scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(clientMock.scan);
             });
@@ -529,7 +566,7 @@ describe('index test', () => {
                 key: 'value'
             });
 
-            return datastore._scan(testFilterParams).then((data) => {
+            return datastore._scan(testFilterParams).then(data => {
                 assert.isOk(data);
                 assert.calledWith(clientMock.scan);
                 assert.notCalled(clientMock.query);
@@ -560,7 +597,7 @@ describe('index test', () => {
                 key: 'value'
             });
 
-            return datastore._scan(testFilterParams).then((data) => {
+            return datastore._scan(testFilterParams).then(data => {
                 assert.isOk(data);
                 assert.calledWith(clientMock.scan);
                 assert.calledWith(clientMock.query, 'bar');
@@ -586,7 +623,7 @@ describe('index test', () => {
             scanChainMock.exec.yieldsAsync(null, responseMock);
             scanChainMock.filter.returns(filterMock);
 
-            return datastore._scan(testFilterParams).then((data) => {
+            return datastore._scan(testFilterParams).then(data => {
                 assert.isOk(data);
                 assert.calledWith(clientMock.scan);
                 assert.calledWith(clientMock.query, 'bar');
@@ -614,7 +651,7 @@ describe('index test', () => {
             scanChainMock.exec.yieldsAsync(null, responseMock);
             scanChainMock.filter.returns(filterMock);
 
-            return datastore._scan(testFilterParams).then((data) => {
+            return datastore._scan(testFilterParams).then(data => {
                 assert.isOk(data);
                 assert.calledWith(clientMock.scan);
                 assert.calledWith(scanChainMock.filter, 'stuff');
@@ -659,7 +696,7 @@ describe('index test', () => {
             clientMock.scan.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
-            return datastore._scan(testFilterParams).then((data) => {
+            return datastore._scan(testFilterParams).then(data => {
                 assert.isOk(data);
                 assert.notCalled(scanChainMock.ascending);
             });
@@ -669,7 +706,7 @@ describe('index test', () => {
             scanChainMock.descending.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(null, responseMock);
 
-            return datastore._scan(testParams).then((data) => {
+            return datastore._scan(testParams).then(data => {
                 assert.deepEqual(data, []);
                 assert.calledWith(clientMock.scan);
             });
@@ -678,19 +715,22 @@ describe('index test', () => {
         it('fails when given an unknown table name', () => {
             scanChainMock.exec.yieldsAsync(new Error('cannot find entries in table'));
 
-            return datastore._scan({
-                table: 'tableUnicorn',
-                params: {},
-                paginate: {
-                    count: 2,
-                    page: 2
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            });
+            return datastore
+                ._scan({
+                    table: 'tableUnicorn',
+                    params: {},
+                    paginate: {
+                        count: 2,
+                        page: 2
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                });
         });
 
         it('fails when it encounters an error', () => {
@@ -699,19 +739,22 @@ describe('index test', () => {
             scanChainMock.descending.returns(scanChainMock);
             scanChainMock.exec.yieldsAsync(testError);
 
-            return datastore._scan({
-                table: 'pipelines',
-                params: {},
-                paginate: {
-                    count: 2,
-                    page: 2
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, testError.message);
-            });
+            return datastore
+                ._scan({
+                    table: 'pipelines',
+                    params: {},
+                    paginate: {
+                        count: 2,
+                        page: 2
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, testError.message);
+                });
         });
     });
 });


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
